### PR TITLE
Update docker-compose config to work with "latest" as of 2025-01-25

### DIFF
--- a/.infra/docker-compose.yml
+++ b/.infra/docker-compose.yml
@@ -3,7 +3,7 @@ services:
 
   otel-collector:
     # https://hub.docker.com/r/otel/opentelemetry-collector/tags
-    image: otel/opentelemetry-collector:0.87.0
+    image: otel/opentelemetry-collector:latest
     command: [ "--config=/etc/otel-collector.yml" ]
     volumes:
       - ./otel-collector.yml:/etc/otel-collector.yml

--- a/.infra/otel-collector.yml
+++ b/.infra/otel-collector.yml
@@ -2,12 +2,14 @@ receivers:
   otlp:
     protocols:
       grpc:
+        endpoint: 0.0.0.0:4317
       http:
+        endpoint: 0.0.0.0:4318
         cors:
           allowed_origins:
-            - 'http://*'
-            - 'https://*'
-          allowed_headers: ['*']
+            - "http://*"
+            - "https://*"
+          allowed_headers: ["*"]
 
 exporters:
   otlp:
@@ -16,14 +18,12 @@ exporters:
       insecure: true
   # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/prometheusremotewriteexporter
   prometheusremotewrite:
-    endpoint: 'http://prometheus:9090/api/v1/write'
+    endpoint: "http://prometheus:9090/api/v1/write"
     tls:
       insecure: true
     resource_to_telemetry_conversion:
       enabled: true
-
-  logging/metrics:
-    loglevel: debug
+  debug:
 
 processors:
   batch:
@@ -32,9 +32,9 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [otlp]
+      exporters: [otlp, debug]
       processors: [batch]
     metrics:
       receivers: [otlp]
-      exporters: [prometheusremotewrite]
+      exporters: [prometheusremotewrite, debug]
       processors: [batch]

--- a/.infra/tempo.yml
+++ b/.infra/tempo.yml
@@ -21,6 +21,7 @@ distributor:
       protocols:
         http:
         grpc:
+          endpoint: 0.0.0.0:4317
           max_recv_msg_size_mib: 20
     opencensus:
 
@@ -41,9 +42,9 @@ metrics_generator:
   processor:
     span_metrics:
       dimensions: [
-          'effect_cache_status', # used across app
-          'sessionId', # used across app
-          'query', # currently used for Spotify API calls (TODO improve)
+          "effect_cache_status", # used across app
+          "sessionId", # used across app
+          "query", # currently used for Spotify API calls (TODO improve)
         ]
   storage:
     path: /tmp/tempo/wal
@@ -52,7 +53,7 @@ metrics_generator:
         send_exemplars: true
 
 overrides:
-  metrics_generator_processors: ['service-graphs', 'span-metrics']
+  metrics_generator_processors: ["service-graphs", "span-metrics"]
   metrics_generator_collection_interval: 250ms
   max_bytes_per_trace: 67108864 # 64mb (5mb default)
 


### PR DESCRIPTION
It seems that either `docker compose` networking or the default listen endpoints changed for various containers. I had errors because containers like `tempo` listened to `127.0.0.1:4317`, so they would reject connections from the otel-collector container to`tempo:4317`, since this used their network IP address.

This PR changes such endpoints to use 0.0.0.0:PORT as appropriate to fix these connectivity issues with my version of `docker`:

```
Client:
 Version:           27.4.0
 API version:       1.47
 Go version:        go1.22.10
 Git commit:        bde2b89
 Built:             Sat Dec  7 10:35:43 2024
 OS/Arch:           darwin/arm64
 Context:           desktop-linux

Server: Docker Desktop 4.37.1 (178610)
 Engine:
  Version:          27.4.0
  API version:      1.47 (minimum version 1.24)
  Go version:       go1.22.10
  Git commit:       92a8393
  Built:            Sat Dec  7 10:38:33 2024
  OS/Arch:          linux/arm64
  Experimental:     false
 containerd:
  Version:          1.7.21
  GitCommit:        472731909fa34bd7bc9c087e4c27943f9835f111
 runc:
  Version:          1.1.13
  GitCommit:        v1.1.13-0-g58aa920
 docker-init:
  Version:          0.19.0
  GitCommit:        de40ad0
```